### PR TITLE
Disallow file mods

### DIFF
--- a/.config/constants.php
+++ b/.config/constants.php
@@ -1,7 +1,7 @@
 <?php
 
-define( 'HM_BASIC_AUTH_USER', 'openwebff' );
-define( 'HM_BASIC_AUTH_PW', 'wither-nodding-dues-morals-splat' );
+// Disable writing to the filesystem.
+define( 'DISALLOW_FILE_MODS', true );
 
 // GlotPress configuration.
 define( 'GP_URL_BASE', '/' );


### PR DESCRIPTION
The filesystem isn't writable, so this stops WP from complaining about it, and disables the prompts to update files live.