### PR TITLE
Update to current release of Git Updater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,22 @@
 		"johnpbloch/wordpress": "^6.8",
 		"pantheon-systems/wp-redis": "^1.4",
 		"humanmade/wp-redis-predis-client": "^0.1.2",
-		"afragen/git-updater": "dev-fair@dev",
+		"afragen/git-updater": "^12",
 		"fairpm/fair-parent-theme": "~1.0.1",
 		"humanmade/aws-ses-wp-mail": "dev-master"
+	},
+	"require-dev": {
+		"mcaskill/composer-exclude-files": "^4.0"
 	},
 	"extra": {
 		"installer-paths": {
 			"content/plugins/{$name}/": ["type:wordpress-plugin"],
 			"content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
 			"content/themes/{$name}/": ["type:wordpress-theme"]
-		}
+		},
+		"exclude-from-files": [
+			"freemius/wordpress-sdk/start.php"
+		]
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"johnpbloch/wordpress": "^6.8",
 		"pantheon-systems/wp-redis": "^1.4",
 		"humanmade/wp-redis-predis-client": "^0.1.2",
-		"afragen/git-updater": "^12",
+		"afragen/git-updater": "^12.18",
 		"fairpm/fair-parent-theme": "~1.0.1",
 		"humanmade/aws-ses-wp-mail": "dev-master"
 	},


### PR DESCRIPTION
Update to release of Git Updater.
Exclude Freemius `start.php` from autoloader as this causes issues. This file is required within Git Updater so full function remains.

If/when Freemius fixes the issue, https://github.com/Freemius/wordpress-sdk/issues/806 then the file exclusion can be removed, assuming the package is using the Freemius/wordpress-sdk that contains the fix.