### PR TITLE
Define AE_ROOT for Aspire Explorer packages

### DIFF
--- a/.config/constants.php
+++ b/.config/constants.php
@@ -10,3 +10,6 @@ define( 'GP_TMPL_PATH', dirname( __DIR__ ) . '/content/plugins/f-translate/templ
 // SES configuration.
 define( 'AWS_SES_WP_MAIL_REGION', 'us-east-1' );
 define( 'AWS_SES_WP_MAIL_USE_INSTANCE_PROFILE', true );
+
+// Root path for URL structure for Packages for Aspire Explorer.
+define( 'AE_ROOT', 'packages/' );


### PR DESCRIPTION
Added a constant for the Root path for URL structure for Packages for Aspire Explorer.