### PR TITLE
run build only when tagged

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build and push container
 on:
   push:
     branches: [ main ]
+    tags: [ '*' ]
 
 env:
   REGISTRY: ghcr.io
@@ -28,6 +29,8 @@ jobs:
 
     - name: Build and push
       run: bin/build.sh
+      env:
+        TAG: ${{ github.ref_name }}
 
     - name: Build Summary
       if: always()

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To ignore files from deployment, specify them in `.distignore`.
 **Notes for the infrastructure team:**
 
 ```
-# In this repo (fairpm/site)
+# In this repo (fairpm/server)
 git checkout main
 git tag -f production
 git push --tags

--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ Deployment will eventually be automatic, but in the meantime, the infrastructure
 
 To ignore files from deployment, specify them in `.distignore`.
 
+**Notes for the infrastructure team:**
+
+```
+# In this repo (fairpm/site)
+git checkout main
+git tag -f production
+git push --tags
+
+# Then in the fairpm/infrastructure-private repo
+./jazz
+cd helm/projects/site
+bin/deploy production
+```
 
 ## License
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -40,9 +40,15 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
+extra_tag=''
+[[ -n ${TAG:-} ]] && extra_tag="--tag ghcr.io/fairpm/server:${TAG}"
+
 echo "Building image…" >&2
+
+# shellcheck disable=SC2086
 docker build \
 	--tag ghcr.io/fairpm/server:latest \
+	$extra_tag \
 	--build-context src="$BUILD_DIR" \
 	"$SCRIPT_DIR/container"
 


### PR DESCRIPTION
This runs the container build only when a version is tagged.  To deploy to the fair.pm site, use the `production` tag, then deploy the helm chart (which will default to that tag).
