### PR TITLE
Update & add plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,6 @@ content/plugins/glotpress-wp/
 content/plugins/s3-uploads/
 content/plugins/fastly/
 content/plugins/glossary/
+content/plugins/unconfirmed/
 vendor/
 wordpress/

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
 		"ocean90/public-post-preview": "^3.0",
 		"humanmade/s3-uploads": "^3.0",
 		"wpackagist-plugin/fastly": "^1.2.29",
-		"progress-planner/glossary": "^1.2.0"
+		"progress-planner/glossary": "^1.2.0",
+		"wpackagist-plugin/unconfirmed": "^1.3.7"
 	},
 	"extra": {
 		"installer-paths": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c312b50ecdca09e7681aac1ab55d29c8",
+    "content-hash": "2117b3442151a5b76f01713fbf14fda1",
     "packages": [
         {
             "name": "afragen/git-updater",
@@ -2746,6 +2746,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/fastly/"
+        },
+        {
+            "name": "wpackagist-plugin/unconfirmed",
+            "version": "1.3.7",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/unconfirmed/",
+                "reference": "tags/1.3.7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/unconfirmed.1.3.7.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/unconfirmed/"
         },
         {
             "name": "yoast/wordpress-seo",


### PR DESCRIPTION
Fixes requirements for PP Glossary and for Fastly, updates composer for GitUpdater.

Obsoletes #83.

Adds WPackagist as a provider; fetches Fastly there, since Fastly's repo doesn't offer a composer file.

Corrects the source name for PP Glossary.